### PR TITLE
Kong v1.3 adapt

### DIFF
--- a/kong/plugins/request-throttling/handler.lua
+++ b/kong/plugins/request-throttling/handler.lua
@@ -184,7 +184,6 @@ local function get_next_request_time(conf, current_time)
                                   conf.max_wait_time,
                                   conf.burst_size,
                                   conf.burst_refresh)
-
   return next_time, err
 end
 
@@ -204,7 +203,7 @@ function RequestThrottlingHandler:access(conf)
       kong.log.err("failed to get next request time: ", tostring(err))
       return
     else
-      return responses.send_HTTP_INTERNAL_SERVER_ERROR(err)
+      return kong.response.exit(500, "Internal Server Error")
     end
   end
 
@@ -217,7 +216,7 @@ function RequestThrottlingHandler:access(conf)
         ngx.header[RETRY_AFTER_HEADER] = sleep_time
       end
 
-      return responses.send(429, "API rate limit exceeded")
+      return kong.response.exit(429, "API rate limit exceeded")
     else
       if not conf.hide_client_headers then
         ngx.header[THROTTLING_DELAY_HEADER] = sleep_time

--- a/kong/plugins/request-throttling/handler.lua
+++ b/kong/plugins/request-throttling/handler.lua
@@ -1,7 +1,7 @@
 -- Kong imports
 local BasePlugin = require "kong.plugins.base_plugin"
 local timestamp = require "kong.tools.timestamp"
-local responses = require "kong.tools.responses"
+local responses = kong.response
 local redis = require "resty.redis"
 
 local ngx_log = ngx.log
@@ -141,20 +141,20 @@ local function get_next_request_time(conf, current_time)
   red:set_timeout(conf.redis_timeout)
   local ok, err = red:connect(conf.redis_host, conf.redis_port)
   if not ok then
-    ngx_log(ngx.ERR, "failed to connect to Redis: ", err)
+    kong.log.err("failed to connect to Redis: ", err)
     return nil, err
   end
 
   local times, err = red:get_reused_times()
   if err then
-    ngx_log(ngx.ERR, "failed to get connect reused times: ", err)
+    kong.log.err("failed to get connect reused times: ", err)
     return nil, err
   end
 
   if times == 0 and conf.redis_password and conf.redis_password ~= "" then
     local ok, err = red:auth(conf.redis_password)
     if not ok then
-      ngx_log(ngx.ERR, "failed to auth Redis: ", err)
+      kong.log.err("failed to auth Redis: ", err)
       return nil, err
     end
   end
@@ -170,7 +170,7 @@ local function get_next_request_time(conf, current_time)
 
     local ok, err = red:select(conf.redis_database or 0)
     if not ok then
-      ngx_log(ngx.ERR, "failed to change Redis database: ", err)
+      kong.log.err("failed to change Redis database: ", err)
       return nil, err
     end
   end
@@ -201,7 +201,7 @@ function RequestThrottlingHandler:access(conf)
   local next_time, err = get_next_request_time(conf, current_time)
   if err then
     if conf.fault_tolerant then
-      ngx_log(ngx.ERR, "failed to get next request time: ", tostring(err))
+      kong.log.err("failed to get next request time: ", tostring(err))
       return
     else
       return responses.send_HTTP_INTERNAL_SERVER_ERROR(err)

--- a/kong/plugins/request-throttling/schema.lua
+++ b/kong/plugins/request-throttling/schema.lua
@@ -4,10 +4,10 @@ return {
     { config = {
         type = "record",
         fields = {
-          { interval = { type = "number", required = true }, },
-          { burst_size = { type = "number", default = 1 }, },
-          { burst_refresh = { type = "number", default = 1 }, },
-          { max_wait_time = { type = "number", default = 60000 }, },
+          { interval = { type = "number", required = true, gt = 0 }, },
+          { burst_size = { type = "number", default = 1, gt = 0 }, },
+          { burst_refresh = { type = "number", default = 1, gt = 0 }, },
+          { max_wait_time = { type = "number", default = 60000, gt = -1 }, },
           { limit_by = { type = "string", one_of = {"consumer", "credential", "ip"}, default = "consumer" }, },
           { fault_tolerant = { type = "boolean", default = true }, },
           { redis_host = { type = "string", default = "localhost" }, },
@@ -17,23 +17,10 @@ return {
           { redis_database = { type = "number", default = 0 }, },
           { hide_client_headers = { type = "boolean", default = false }, },
         },
-
         custom_validator = function(config)
           -- basic validations TODO: extend?
-          if config.interval < 1 then
-            return nil, "config.interval must be greather than or equal to 1"
-          end
-          if config.burst_size < 1 then
-            return nil, "config.burst_size must be greater than or equal to 1"
-          end
-          if config.burst_refresh < 1 then
-            return nil, "config.burst_refresh must be greater than or equal to 1"
-          end
           if config.burst_refresh > config.burst_size then
             return nil, "config.burst_refresh must be lower than or equal to config.burst_size"
-          end
-          if config.max_wait_time < 0 then
-            return nil, "config.max_wait_time must be greater than or equal to 0"
           end
           if config.max_wait_time > 0 and config.interval >= config.max_wait_time then
             return nil, "config.interval must be lower than config.max_wait_time"

--- a/kong/plugins/request-throttling/schema.lua
+++ b/kong/plugins/request-throttling/schema.lua
@@ -1,41 +1,46 @@
-local Errors = require "kong.dao.errors"
-
 return {
+  name = "request-throttling",
   fields = {
-    interval = { type = "number", required = true },
-    burst_size = { type = "number", default = 1},
-    burst_refresh = { type = "number", default = 1},
-    max_wait_time = { type = "number", default = 60000 },
-    limit_by = { type = "string", enum = {"consumer", "credential", "ip"}, default = "consumer" },
-    fault_tolerant = { type = "boolean", default = true },
-    redis_host = { type = "string", default = "localhost" },
-    redis_port = { type = "number", default = 6379 },
-    redis_password = { type = "string" },
-    redis_timeout = { type = "number", default = 2000 },
-    redis_database = { type = "number", default = 0 },
-    hide_client_headers = { type = "boolean", default = false }
-  },
-  self_check = function(schema, plugin_t, dao, is_update)
-    -- basic validations TODO: extend?
-    if plugin_t.interval < 1 then
-      return false, Errors.schema "config.interval must be greather than or equal to 1"
-    end
-    if plugin_t.burst_size < 1 then
-      return false, Errors.schema "config.burst_size must be greater than or equal to 1"
-    end
-    if plugin_t.burst_refresh < 1 then
-      return false, Errors.schema "config.burst_refresh must be greater than or equal to 1"
-    end
-    if plugin_t.burst_refresh > plugin_t.burst_size then
-      return false, Errors.schema "config.burst_refresh must be lower than or equal to config.burst_size"
-    end
-    if plugin_t.max_wait_time < 0 then
-      return false, Errors.schema "config.max_wait_time must be greater than or equal to 0"
-    end
-    if plugin_t.max_wait_time > 0 and plugin_t.interval >= plugin_t.max_wait_time then
-      return false, Errors.schema "config.interval must be lower than config.max_wait_time"
-    end
+    { config = {
+        type = "record",
+        fields = {
+          { interval = { type = "number", required = true }, },
+          { burst_size = { type = "number", default = 1 }, },
+          { burst_refresh = { type = "number", default = 1 }, },
+          { max_wait_time = { type = "number", default = 60000 }, },
+          { limit_by = { type = "string", one_of = {"consumer", "credential", "ip"}, default = "consumer" }, },
+          { fault_tolerant = { type = "boolean", default = true }, },
+          { redis_host = { type = "string", default = "localhost" }, },
+          { redis_port = { type = "number", default = 6379 }, },
+          { redis_password = { type = "string" }, },
+          { redis_timeout = { type = "number", default = 2000 }, },
+          { redis_database = { type = "number", default = 0 }, },
+          { hide_client_headers = { type = "boolean", default = false }, },
+        },
 
-    return true
-  end
+        custom_validator = function(config)
+          -- basic validations TODO: extend?
+          if config.interval < 1 then
+            return nil, "config.interval must be greather than or equal to 1"
+          end
+          if config.burst_size < 1 then
+            return nil, "config.burst_size must be greater than or equal to 1"
+          end
+          if config.burst_refresh < 1 then
+            return nil, "config.burst_refresh must be greater than or equal to 1"
+          end
+          if config.burst_refresh > config.burst_size then
+            return nil, "config.burst_refresh must be lower than or equal to config.burst_size"
+          end
+          if config.max_wait_time < 0 then
+            return nil, "config.max_wait_time must be greater than or equal to 0"
+          end
+          if config.max_wait_time > 0 and config.interval >= config.max_wait_time then
+            return nil, "config.interval must be lower than config.max_wait_time"
+          end
+          return true
+        end
+      },
+    },
+  },
 }


### PR DESCRIPTION
The plugin now works with kong v1.3. 
- The error log which used nginx log has been replace by kong error log because Kong recommends doing this way.
- Http responses have been udated.
- Certain schema fields validation has been updated to use the new validation method available since kong v1.0.